### PR TITLE
Call plans through action designators

### DIFF
--- a/ltfnp_executive/ltfnp-executive.asd
+++ b/ltfnp_executive/ltfnp-executive.asd
@@ -69,10 +69,18 @@
                                         "reasoning"
                                         "sem-map-config"
                                         "facts"))
+     (:file "plans-process-module" :depends-on ("package"
+                                                "utils"
+                                                "costmap-metadata"
+                                                "reasoning"
+                                                "sem-map-config"
+                                                "facts"
+                                                "plan-library"))
      (:file "top-level-plans" :depends-on ("package"
                                            "utils"
                                            "costmap-metadata"
                                            "reasoning"
                                            "sem-map-config"
                                            "plan-library"
-                                           "facts"))))))
+                                           "facts"
+                                           "plans-process-module"))))))

--- a/ltfnp_executive/src/plan-library.lisp
+++ b/ltfnp_executive/src/plan-library.lisp
@@ -102,15 +102,20 @@
 
 (def-cram-function pick-object (object)
   ;; Assumptions: Object accessible, approached
+  (format t "Trying to pick object up~%")
   )
 
 (def-cram-function fetch-object (object)
-  (when-failure ((:object-not-found (format t "Fail~%")))
-    (find-object object))
-  (when-failure ((:location-not-reached (format t "Fail~%"))
-                 (:manipulation-pose-unreachable (format t "Fail~%"))
-                 (:manipulation-failed (format t "Fail~%")))
-    (pick-object object)))
+  (with-designators ((find-action :action `((:to :find)
+                                            (:obj ,object)))
+                     (pick-action :action `((:to :pick)
+                                            (:obj ,object))))
+    (when-failure ((:object-not-found
+                    (ros-warn (ltfnp) "fetch-object: object not found")))
+      (perform find-action))
+    (when-failure ((:manipulation-pose-unreachable (format t "Fail~%"))
+                   (:manipulation-failed (format t "Fail~%")))
+      (perform pick-action))))
 
 (def-cram-function put-object (object location)
   ;; Assumptions: Location accessible, approached

--- a/ltfnp_executive/src/plans-process-module.lisp
+++ b/ltfnp_executive/src/plans-process-module.lisp
@@ -1,0 +1,43 @@
+;;; Copyright (c) 2016, Jan Winkler <winkler@cs.uni-bremen.de>
+;;; All rights reserved.
+;;; 
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;; 
+;;; * Redistributions of source code must retain the above copyright
+;;;   notice, this list of conditions and the following disclaimer.
+;;; * Redistributions in binary form must reproduce the above copyright
+;;;   notice, this list of conditions and the following disclaimer in the
+;;;   documentation and/or other materials provided with the distribution.
+;;; 
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :ltfnp-executive)
+
+
+(def-fact-group eating-plans (action-desig)
+  
+  (<- (action-desig ?action-designator (fetch-object ?current-object))
+    (desig-prop ?action-designator (:to :fetch))
+    (desig-prop ?action-designator (:obj ?object))
+    (desig:current-designator ?object ?current-object))
+  
+  (<- (action-desig ?action-designator (find-object ?current-object))
+    (desig-prop ?action-designator (:to :find))
+    (desig-prop ?action-designator (:obj ?object))
+    (desig:current-designator ?object ?current-object))
+  
+  (<- (action-desig ?action-designator (pick-object ?current-object))
+    (desig-prop ?action-designator (:to :pick))
+    (desig-prop ?action-designator (:obj ?object))
+    (desig:current-designator ?object ?current-object)))

--- a/ltfnp_executive/src/top-level-plans.lisp
+++ b/ltfnp_executive/src/top-level-plans.lisp
@@ -64,7 +64,7 @@
     (with-designators ((loc-on-sink :location `((:on "CounterTop")
                                                 (:name "iai_kitchen_sink_area_counter_top")))
                        (milk :object `((:type "Milk")
-                                       (:at ,loc-on-sink))))
-      (find-object milk))
-    ;; TODO: Add activity here
-    ))
+                                       (:at ,loc-on-sink)))
+                       (fetch-action :action `((:to :fetch)
+                                               (:obj ,milk))))
+      (perform fetch-action))))


### PR DESCRIPTION
Right now, the `fetch`, `find`, and `pick` plans are called through action designators.

Based on https://github.com/cram2/cram_plans/commit/e5f09515f82d474052dc50b9fa9bb96c873159f6.
