### PR TITLE
Commenting out `projection_type` from world file

### DIFF
--- a/ltfnp_gazebo/worlds/empty_world_with_plugins.world
+++ b/ltfnp_gazebo/worlds/empty_world_with_plugins.world
@@ -17,7 +17,7 @@
       <camera name='user_camera'>
         <pose frame=''>-2.36603 -4.4773 3.65853 0 0.599643 1.01619</pose>
         <view_controller>orbit</view_controller>
-        <projection_type>perspective</projection_type>
+        <!--projection_type>perspective</projection_type-->
       </camera>
     </gui>
     


### PR DESCRIPTION
This doesn't run on Gazebo 2.2.3 (SDF 1.4)

@gheorghelisca sorry, I was overly optimistic about this when I merged the pull request. Commenting out the `projection_type` field under `camera` makes it work, though; can you verify whether this still works fine for you? Thanks!
